### PR TITLE
Add VASelectionStyle.none

### DIFF
--- a/VACalendar/VACalendarView.swift
+++ b/VACalendar/VACalendarView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public enum VASelectionStyle {
-    case single, multi
+    case single, multi, none
 }
 
 public enum VACalendarScrollDirection {
@@ -291,6 +291,10 @@ extension VACalendarView: VAMonthViewDelegate {
             
         case .multi:
             calendar.setDaySelectionState(day, state: day.reverseSelectionState)
+            
+        case .none:
+            calendarDelegate?.selectedDate?(day.date)
+            break
         }
     }
     


### PR DESCRIPTION
In case we want to have several pre-selected dates and we don't want the user to add or remove dates. The user still can click on date without select it though. 

ie: 
        calendarView.selectionStyle = .none
        calendarView.selectDates(self.dates)
